### PR TITLE
updated regex to avoid matching pages with similar names

### DIFF
--- a/src/jquery.mobile.paramsHandler-1.4.2.js
+++ b/src/jquery.mobile.paramsHandler-1.4.2.js
@@ -20,7 +20,7 @@ $.mobile.paramsHandler = {
             for (var i in pages) {
 
                 var page = pages[i];
-                var re = "^#" + page.id;
+                var re = "^#" + page.id + "(\?|$)";
 
                 if (u.hash.search(re) !== -1) {
                     pageMatch = page;


### PR DESCRIPTION
Hi there,

Excellent little plugin.  This functionality should be in the core.  Don't know why it's so hard to pass params between pages...

I updated your regex so that it would not match two pages that have similar pages.  For example, if your current page structure looks like:

```
<!-- page to display one dog -->
<div data-role="page" id="dog">...</div>

<!-- page to display a list of dogs -->
<div data-role="page" id="dogs">...</div>
```

and your javascript looks like:

```
$.mobile.paramsHandler.addPage( "dog", [ "id" ], [], showDog );
$.mobile.paramsHandler.init();
```

Then when you transition to the `#dogs` page, the regex for `#dog` matches and the paramsHandler callback gets fired, even though it shouldn't.  By looking explicitly for the `?` or end of string, you can avoid that.

Thanks for this plugin!!!
Morgan
