### PR TITLE
fixed regex syntax to match javascript flavor

### DIFF
--- a/src/jquery.mobile.paramsHandler-1.4.2.js
+++ b/src/jquery.mobile.paramsHandler-1.4.2.js
@@ -20,7 +20,7 @@ $.mobile.paramsHandler = {
             for (var i in pages) {
 
                 var page = pages[i];
-                var re = "^#" + page.id + "(\?|$)";
+                var re = "^#" + page.id + "(\\?|$)";
 
                 if (u.hash.search(re) !== -1) {
                     pageMatch = page;


### PR DESCRIPTION
Sigh.  Sorry for sending my pull request earlier without thoroughly testing.  The regex I sent worked in my regex tester, but I hadn't made sure it worked within the plugin.

Should work now.
