### PR TITLE
add new history entries when navigating with new parameters values on the same page

### DIFF
--- a/src/jquery.mobile.paramsHandler-1.4.2.js
+++ b/src/jquery.mobile.paramsHandler-1.4.2.js
@@ -58,7 +58,11 @@ $.mobile.paramsHandler = {
 
             $(":mobile-pagecontainer").pagecontainer("change", "#" + pageMatch.id, data.options);
 
-            window.history.replaceState(null, null, u.href);
+            if (location.href != u.href && location.href.split('?')[0]===u.href.split('?')[0] && location.href.split('?').length > 1) {
+                window.history.pushState(null, null, u.href);
+            } else {
+                window.history.replaceState(null, null, u.href);
+            }
 
             e.preventDefault();
         });


### PR DESCRIPTION
Until now, going from #one to #two?id=me to #two?id=you and then hitting the back button would go to #one and not #two?id=me.
